### PR TITLE
use yaml.safeLoadAll to load YAML document

### DIFF
--- a/lib/linter-js-yaml.coffee
+++ b/lib/linter-js-yaml.coffee
@@ -19,7 +19,7 @@ module.exports =
         return new Promise (resolve)->
           messages = []
           try
-            yaml.safeLoad textEditor.getText(), onWarning: (warning) ->
+            yaml.safeLoadAll textEditor.getText(), ((doc) -> null), onWarning: (warning) ->
               messages.push(provider.processMessage('Warning', textEditor.getPath(), warning))
           catch error
             messages.push(provider.processMessage('Error', textEditor.getPath(), error))


### PR DESCRIPTION
Allows to use the linter on multidocument YAML files.

Fixes #9.
