### PR TITLE
Use proper line numbers

### DIFF
--- a/lib/linter-js-yaml.js
+++ b/lib/linter-js-yaml.js
@@ -39,17 +39,22 @@ export default {
       lintOnFly: true,
       lint: (TextEditor) => {
         const filePath = TextEditor.getPath();
-        const fileText = TextEditor.buffer.cachedText;
+        const fileText = TextEditor.getText();
 
         const messages = [];
         const processMessage = (type, message) => {
-          const line = message.mark.line;
+          let line = message.mark.line;
+          // Workaround for https://github.com/nodeca/js-yaml/issues/218
+          const maxLine = TextEditor.getLineCount() - 1;
+          if (line > maxLine) {
+            line = maxLine;
+          }
           const column = message.mark.column;
           return {
             type: type,
             text: message.reason,
             filePath: filePath,
-            range: helper.rangeFromLineNumber(TextEditor, line - 1, column - 1),
+            range: helper.rangeFromLineNumber(TextEditor, line, column),
           };
         };
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "apm test"
   },
   "dependencies": {
-    "atom-linter": "^3.3.5",
+    "atom-linter": "^3.3.7",
     "atom-package-deps": "^3.0.2",
     "js-yaml": "3.4.3"
   },


### PR DESCRIPTION
Partially reverts #18.

Turns out this linter can report line numbers past the end of the input, leading to an assumption earlier that it was using 1 based indexes.

When a line number is seen that is past the end of the input force the last line of the file.