### PR TITLE
Fix CircleCI container

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,11 @@
 dependencies:
+  pre:
+    # Force updating wget due to the current containers being too out of date
+    - sudo apt-get update
+    - sudo apt-get install wget
   override:
     - wget -O atom-amd64.deb https://atom.io/download/deb
-    - sudo apt-get update
+    # - sudo apt-get update # Cut out until wget is fixed on the containers
     - sudo dpkg --install atom-amd64.deb || true
     - sudo apt-get -f install -y
     - atom -v


### PR DESCRIPTION
For some bizarre reason the new CircleCI containers ship with a broken and old version of wget, force updating it so that we can download Atom.