### PR TITLE
Update the readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+If you would like to contribute enhancements or fixes, please do the following:
+
+1. Fork the plugin repository
+2. Hack on a separate topic branch created from the latest `master`
+3. Commit and push the topic branch
+4. Make a pull request
+5. Welcome to the club!
+
+Please note that modifications should follow these coding guidelines:
+
+* Indent is 2 spaces with `.editorconfig`
+* Code should pass `eslint` linter
+* Vertical whitespace helps readability, don’t be afraid to use it
+
+**Thank you for helping out!**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # linter-js-yaml
 
-This package will lint your `.yaml` opened files in Atom through [js-yaml](https://github.com/connec/yaml-js).
+This package will parse your YAML files in Atom through
+[js-yaml](https://github.com/connec/yaml-js), exposing any issues reported.
 
 #### Installation
 
@@ -21,21 +22,3 @@ You can configure linter-js-yaml by editing ~/.atom/config.cson (choose Open You
 ```
 
 * `customTags`: List of YAML custom tags. (Default: scalar)
-
-## Contributing
-
-If you would like to contribute enhancements or fixes, please do the following:
-
-1. Fork the plugin repository
-2. Hack on a separate topic branch created from the latest `master`
-3. Commit and push the topic branch
-4. Make a pull request
-5. Welcome to the club!
-
-Please note that modifications should follow these coding guidelines:
-
-* Indent is 2 spaces with `.editorconfig`
-* Code should pass `eslint` linter with the provided `.eslintrc`
-* Vertical whitespace helps readability, don’t be afraid to use it
-
-**Thank you for helping out!**


### PR DESCRIPTION
Updates the readme to not call `js-yaml` a linter.
Splits out the contributing section.

Fixes #20.