### PR TITLE
Move to eslint-config-airbnb-base

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "activationCommands": [],
   "engines": {
-    "atom": ">=1.0.0"
+    "atom": ">=1.0.0 <2.0.0"
   },
   "main": "./lib/linter-js-yaml.js",
   "scripts": {
@@ -15,14 +15,14 @@
     "test": "apm test"
   },
   "dependencies": {
-    "atom-linter": "^4.5.1",
+    "atom-linter": "^4.7.0",
     "atom-package-deps": "^4.0.1",
     "js-yaml": "^3.5.4"
   },
   "devDependencies": {
-    "eslint": "^2.4.0",
-    "eslint-config-airbnb": "^6.2.0",
-    "eslint-plugin-react": "^4.2.3"
+    "eslint": "^2.8.0",
+    "eslint-config-airbnb-base": "^1.0.3",
+    "eslint-plugin-import": "^1.5.0"
   },
   "package-deps": [
     "linter"
@@ -35,7 +35,11 @@
     }
   },
   "eslintConfig": {
-    "extends": "airbnb/base",
+    "extends": "airbnb-base",
+    "rules": {
+      "global-require": 0,
+      "import/no-unresolved": [2, { "ignore": ["atom"] }]
+    },
     "env": {
       "es6": true,
       "node": true


### PR DESCRIPTION
We don't need the React related stuff from eslint-config-airbnb, so this switches to the base ruleset.

Closes #56.
Closes #57.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-js-yaml/58)
<!-- Reviewable:end -->
