### PR TITLE
Update CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,38 @@
-sudo: true
-git:
-  depth: 10
-branches:
-  only:
-    - master
+### Project specific config ###
+language: generic
+
+matrix:
+  include:
+    - os: linux
+      env: ATOM_CHANNEL=stable
+
+    - os: linux
+      env: ATOM_CHANNEL=beta
+
+    - os: osx
+      env: ATOM_CHANNEL=stable
+
+### Generic setup follows ###
+script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+
 notifications:
   email:
     on_success: never
     on_failure: change
-os: osx
 
-script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+branches:
+  only:
+    - master
+
+git:
+  depth: 10
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+    - build-essential
+    - git
+    - libgnome-keyring-dev
+    - fakeroot

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,20 @@
-version: "{build}"
-os: Windows Server 2012 R2
+### Project specific config ###
+environment:
+  matrix:
+  - ATOM_CHANNEL: stable
+  - ATOM_CHANNEL: beta
+
+### Generic setup follows ###
+build_script:
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/atom/ci/master/build-package.ps1'))
+
 branches:
   only:
     - master
+
+version: "{build}"
+platform: x64
+clone_depth: 10
+skip_tags: true
 test: off
 deploy: off
-
-install:
-  - appveyor DownloadFile https://atom.io/download/windows -FileName AtomSetup.exe
-  - AtomSetup.exe /silent
-
-build_script:
-  - cd %APPVEYOR_BUILD_FOLDER%
-  - SET PATH=%LOCALAPPDATA%\atom\bin;%PATH%
-  - apm clean
-  - apm install
-  - apm test

--- a/circle.yml
+++ b/circle.yml
@@ -1,17 +1,8 @@
-dependencies:
-  pre:
-    # Force updating wget due to the current containers being too out of date
-    - sudo apt-get update
-    - sudo apt-get install wget
-  override:
-    - wget -O atom-amd64.deb https://atom.io/download/deb
-    # - sudo apt-get update # Cut out until wget is fixed on the containers
-    - sudo dpkg --install atom-amd64.deb || true
-    - sudo apt-get -f install -y
-    - atom -v
-    - apm install
 test:
   override:
-    - ./node_modules/.bin/eslint lib
-    - ./node_modules/.bin/eslint spec
-    - apm test
+    - curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh
+
+dependencies:
+  override:
+    # If nothing is put here, CircleCI will run `npm install` using the system Node.js
+    - echo "Managed in the script"


### PR DESCRIPTION
* Move CircleCI to the same script Travis-CI uses on atom/ci
* Enable building on Linux on Travis-CI
* Cut out the beta build on OS X on Travis-CI
* Enable building beta on AppVeyor
* Use the atom/ci script on AppVeyor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-js-yaml/90)
<!-- Reviewable:end -->
