### PR TITLE
add ability to set `kind` when setting customTags from config.cson

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 # linter-js-yaml
 
-This package will parse your YAML files in Atom through
-[js-yaml](https://github.com/connec/yaml-js), exposing any issues reported.
+This package will parse your YAML files in Atom through [js-yaml](https://github.com/connec/yaml-js), exposing any issues reported.
 
-#### Installation
+## Installation
 
 ```
 $ apm install linter-js-yaml
 ```
 
-#### Settings
+## Settings
 
 You can configure linter-js-yaml by editing ~/.atom/config.cson (choose Open Your Config in Atom menu) or in Preferences:
 
@@ -18,7 +17,19 @@ You can configure linter-js-yaml by editing ~/.atom/config.cson (choose Open You
   'customTags': [
     "!yaml"
     "!include"
+    {
+      tag:  "!Base64"
+      kind: "mapping"
+    }
+    {
+      tag:  "!Equals"
+      kind: "sequence"
+    }
+    {
+      tag: "!If"
+      # kind defaults to `scalar`
+    }
   ]
 ```
 
-* `customTags`: List of YAML custom tags. (Default: scalar)
+- `customTags`: List of YAML custom tags. (Default: scalar, unless `kind` is set)

--- a/lib/linter-js-yaml.js
+++ b/lib/linter-js-yaml.js
@@ -23,14 +23,13 @@ export default {
     this.subscriptions = new CompositeDisposable();
     this.subscriptions.add(atom.config.observe('linter-js-yaml.customTags', (customTags) => {
       const customTypeTags = [];
-      customTags.map((tag) => {
+      customTags.forEach((tag) => {
         if (typeof tag === 'object') {
           customTypeTags.push(new yaml.Type(tag.tag, { kind: tag.kind || 'scalar' }));
         }
         if (typeof tag === 'string') {
           customTypeTags.push(new yaml.Type(tag, { kind: 'scalar' }));
         }
-        return this;
       });
       this.Schema = yaml.Schema.create(customTypeTags);
     }));

--- a/lib/linter-js-yaml.js
+++ b/lib/linter-js-yaml.js
@@ -22,12 +22,15 @@ export default {
 
     this.subscriptions = new CompositeDisposable();
     this.subscriptions.add(atom.config.observe('linter-js-yaml.customTags', (customTags) => {
-      let customTypeTags = [];
-      customTags.map(tag => {
-        if (typeof tag === 'object')
+      const customTypeTags = [];
+      customTags.map((tag) => {
+        if (typeof tag === 'object') {
           customTypeTags.push(new yaml.Type(tag.tag, { kind: tag.kind || 'scalar' }));
-        if (typeof tag === 'string')
+        }
+        if (typeof tag === 'string') {
           customTypeTags.push(new yaml.Type(tag, { kind: 'scalar' }));
+        }
+        return this;
       });
       this.Schema = yaml.Schema.create(customTypeTags);
     }));

--- a/lib/linter-js-yaml.js
+++ b/lib/linter-js-yaml.js
@@ -22,9 +22,14 @@ export default {
 
     this.subscriptions = new CompositeDisposable();
     this.subscriptions.add(atom.config.observe('linter-js-yaml.customTags', (customTags) => {
-      this.Schema = yaml.Schema.create(customTags.map(tag =>
-        new yaml.Type(tag, { kind: 'scalar' })
-      ));
+      let customTypeTags = [];
+      customTags.map(tag => {
+        if (typeof tag === 'object')
+          customTypeTags.push(new yaml.Type(tag.tag, { kind: tag.kind || 'scalar' }));
+        if (typeof tag === 'string')
+          customTypeTags.push(new yaml.Type(tag, { kind: 'scalar' }));
+      });
+      this.Schema = yaml.Schema.create(customTypeTags);
     }));
   },
 


### PR DESCRIPTION
This pull request adds the ability to include the `kind` of a custom YAML tag set in the `customTags` property in one's Atom config, but still defaults to `scalar` if not provided.

I added this change specifically for linting AWS CloudFormation's recently added YAML support and local tags. 

Since `scalar` isn't always the kind needed I think this would be a useful feature for other users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-js-yaml/94)
<!-- Reviewable:end -->
