### PR TITLE
Improve Atom startup time

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/AtomLinter/linter-js-yaml.git",
   "homepage": "https://github.com/AtomLinter/linter-js-yaml",
   "license": "MIT",
-  "activationCommands": [],
+  "activationHooks": ["language-yaml:grammar-used"],
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },

--- a/spec/linter-spec.js
+++ b/spec/linter-spec.js
@@ -11,20 +11,16 @@ describe('Js-YAML provider for Linter', () => {
   const lint = require('../lib/linter-js-yaml.js').provideLinter().lint;
 
   beforeEach(() => {
-    // This whole beforeEach function is inspired by:
-    // https://github.com/AtomLinter/linter-jscs/pull/295/files
-    //
-    // See also:
-    // https://discuss.atom.io/t/activationhooks-break-unit-tests/36028/8
+    // Info about this beforeEach() implementation:
+    // https://github.com/AtomLinter/Meta/issues/15
     const activationPromise = atom.packages.activatePackage('linter-js-yaml').then(() =>
       atom.config.set('linter-js-yaml.customTags', ['!yaml', '!include'])
     );
 
     waitsForPromise(() =>
-      atom.packages.activatePackage('language-yaml'));
-
-    waitsForPromise(() =>
-      atom.workspace.open(travisYml));
+      atom.packages.activatePackage('language-yaml').then(() =>
+        atom.workspace.open(travisYml)
+    ));
 
     atom.packages.triggerDeferredActivationHooks();
     waitsForPromise(() => activationPromise);

--- a/spec/linter-spec.js
+++ b/spec/linter-spec.js
@@ -2,7 +2,6 @@
 
 import * as path from 'path';
 
-const travisYml = path.join(__dirname, '.travis.yml');
 const badPath = path.join(__dirname, 'files', 'bad.yaml');
 const issue2Path = path.join(__dirname, 'files', 'issue-2.yaml');
 const issue9Path = path.join(__dirname, 'files', 'issue-9.yaml');
@@ -19,7 +18,7 @@ describe('Js-YAML provider for Linter', () => {
 
     waitsForPromise(() =>
       atom.packages.activatePackage('language-yaml').then(() =>
-        atom.workspace.open(travisYml)
+        atom.workspace.open('ok-if-it-doesnt-exist.yml')
     ));
 
     atom.packages.triggerDeferredActivationHooks();


### PR DESCRIPTION
Before this change, activation was done on Atom startup, whether or not
you actually had any YAML files open.

With this change in place, we postpone activation until the Atom YAML
grammar's first use.

This improves startup time of my Atom by about 80ms, is one of the top
startup time offenders according to TimeCop.

For some frame of reference, I have 124 packages installed, and Timecop
lists all packages with startup times above 5ms.