### PR TITLE
Delay activation until needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/AtomLinter/linter-js-yaml.git",
   "homepage": "https://github.com/AtomLinter/linter-js-yaml",
   "license": "MIT",
-  "activationCommands": [],
+  "activationHooks": ["language-yaml:grammar-used"],
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },


### PR DESCRIPTION
Don't activate until the user actually opens a YAML file.

This change saves me about 40ms of Atom startup time.

For more details, search for `activationHooks` on
http://flight-manual.atom.io/hacking-atom/sections/package-word-count/