### PR TITLE
Asyncify the specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "devDependencies": {
     "eslint": "^4.6.0",
     "eslint-config-airbnb-base": "^12.0.0",
-    "eslint-plugin-import": "^2.7.0"
+    "eslint-plugin-import": "^2.7.0",
+    "jasmine-fix": "^1.3.0"
   },
   "package-deps": [
     "linter"

--- a/spec/linter-spec.js
+++ b/spec/linter-spec.js
@@ -1,5 +1,7 @@
 'use babel';
 
+// eslint-disable-next-line no-unused-vars
+import { it, fit, wait, beforeEach, afterEach } from 'jasmine-fix';
 import * as path from 'path';
 
 const badPath = path.join(__dirname, 'files', 'bad.yaml');
@@ -9,42 +11,41 @@ const issue9Path = path.join(__dirname, 'files', 'issue-9.yaml');
 describe('Js-YAML provider for Linter', () => {
   const { lint } = require('../lib/linter-js-yaml.js').provideLinter();
 
-  beforeEach(() => {
+  beforeEach(async () => {
     // Info about this beforeEach() implementation:
     // https://github.com/AtomLinter/Meta/issues/15
-    const activationPromise = atom.packages.activatePackage('linter-js-yaml').then(() =>
-      atom.config.set('linter-js-yaml.customTags', ['!yaml', '!include']));
+    const activationPromise = atom.packages.activatePackage('linter-js-yaml');
 
-    waitsForPromise(() =>
-      atom.packages.activatePackage('language-yaml').then(() =>
-        atom.workspace.open(badPath)));
+    await atom.packages.activatePackage('language-yaml');
+    await atom.workspace.open(badPath);
 
     atom.packages.triggerDeferredActivationHooks();
-    waitsForPromise(() => activationPromise);
+    await activationPromise;
+    atom.config.set('linter-js-yaml.customTags', ['!yaml', '!include']);
   });
 
-  it('finds something wrong with bad.yaml', () =>
-    waitsForPromise(() =>
-      atom.workspace.open(badPath).then((editor) => {
-        const messages = lint(editor);
-        expect(messages.length).toBe(1);
-        expect(messages[0].type).toBe('Error');
-        expect(messages[0].text).toBe('end of the stream or a document separator is expected');
-        expect(messages[0].filePath).toBe(badPath);
-        expect(messages[0].range).toEqual([[2, 4], [2, 5]]);
-      })));
+  it('finds something wrong with bad.yaml', async () => {
+    const editor = await atom.workspace.open(badPath);
+    const messages = await lint(editor);
 
-  it('finds nothing wrong with issue-2.yaml.', () =>
-    waitsForPromise(() =>
-      atom.workspace.open(issue2Path).then((editor) => {
-        const messages = lint(editor);
-        expect(messages.length).toBe(0);
-      })));
+    expect(messages.length).toBe(1);
+    expect(messages[0].type).toBe('Error');
+    expect(messages[0].text).toBe('end of the stream or a document separator is expected');
+    expect(messages[0].filePath).toBe(badPath);
+    expect(messages[0].range).toEqual([[2, 4], [2, 5]]);
+  });
 
-  it('finds nothing wrong with issue-9.yaml.', () =>
-    waitsForPromise(() =>
-      atom.workspace.open(issue9Path).then((editor) => {
-        const messages = lint(editor);
-        expect(messages.length).toBe(0);
-      })));
+  it('finds nothing wrong with issue-2.yaml.', async () => {
+    const editor = await atom.workspace.open(issue2Path);
+    const messages = await lint(editor);
+
+    expect(messages.length).toBe(0);
+  });
+
+  it('finds nothing wrong with issue-9.yaml.', async () => {
+    const editor = await atom.workspace.open(issue9Path);
+    const messages = await lint(editor);
+
+    expect(messages.length).toBe(0);
+  });
 });


### PR DESCRIPTION
Bring in `jasmine-fix` to allow the use of `async`/`await` in the specs and refactor them to take advantage of this.