### PR TITLE
Guard against invalid TextEditors

### DIFF
--- a/lib/linter-js-yaml.js
+++ b/lib/linter-js-yaml.js
@@ -39,7 +39,14 @@ export default {
       name: 'Js-YAML',
       lintOnFly: true,
       lint: (TextEditor) => {
+        if (!atom.workspace.isTextEditor(TextEditor)) {
+          return null;
+        }
         const filePath = TextEditor.getPath();
+        if (!filePath) {
+          // Invalid path
+          return null;
+        }
         const fileText = TextEditor.getText();
 
         const messages = [];


### PR DESCRIPTION
Verify that what we are passed is a valid TextEditor, and check that it has a path before attempting to lint.

Fixes #120.