### PR TITLE
Initial Adoption of Continous Deployment using semantic-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,15 @@ addons:
     - fakeroot
     - git
     - libsecret-1-dev
+
+node_js: lts/*
+
+after_success:
+  # Add apm to the PATH
+  - export PATH=${PATH}:${HOME}/atom/usr/bin/
+
+deploy:
+  provider: script
+  skip_cleanup: true
+  script:
+    - npx semantic-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ### Project specific config ###
-language: generic
+language: node_js
+node_js: lts/*
 
 matrix:
   include:
@@ -9,11 +10,24 @@ matrix:
     - os: linux
       env: ATOM_CHANNEL=beta
 
+before_script:
+  - commitlint-travis
+
+after_success:
+  # Add apm to the PATH
+  - export PATH=${PATH}:${HOME}/atom/usr/bin/
+
+deploy:
+  provider: script
+  skip_cleanup: true
+  script:
+    - npx semantic-release
+
 ### Generic setup follows ###
 script:
   - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
   - chmod u+x build-package.sh
-  - ./build-package.sh
+  - "./build-package.sh"
 
 notifications:
   email:
@@ -23,6 +37,7 @@ notifications:
 branches:
   only:
     - master
+    - "/^greenkeeper/.*$/"
 
 git:
   depth: 10
@@ -38,15 +53,3 @@ addons:
     - fakeroot
     - git
     - libsecret-1-dev
-
-node_js: lts/*
-
-after_success:
-  # Add apm to the PATH
-  - export PATH=${PATH}:${HOME}/atom/usr/bin/
-
-deploy:
-  provider: script
-  skip_cleanup: true
-  script:
-    - npx semantic-release

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "linter-js-yaml",
   "version": "1.2.8",
   "description": "Linter plugin for YAML, using js-yaml",
-  "repository": "https://github.com/AtomLinter/linter-js-yaml.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AtomLinter/linter-js-yaml.git"
+  },
   "homepage": "https://github.com/AtomLinter/linter-js-yaml",
   "license": "MIT",
   "activationHooks": [

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "lint": "eslint .",
-    "test": "apm test"
+    "test": "atom --test spec"
   },
   "dependencies": {
     "atom-linter": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },
-  "main": "./lib/linter-js-yaml.js",
+  "main": "./lib/linter-js-yaml",
   "scripts": {
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "main": "./lib/linter-js-yaml.js",
   "scripts": {
+    "commitmsg": "commitlint -e $GIT_PARAMS",
     "lint": "eslint .",
     "test": "apm test"
   },
@@ -22,6 +23,12 @@
     "js-yaml": "^3.10.0"
   },
   "devDependencies": {
+    "@commitlint/cli": "^6.1.3",
+    "@commitlint/config-conventional": "^6.1.3",
+    "@commitlint/travis-cli": "^6.1.3",
+    "@semantic-release/apm-config": "^2.0.1",
+    "husky": "^0.14.3",
+    "semantic-release": "^15.1.7",
     "eslint": "^4.6.0",
     "eslint-config-airbnb-base": "^12.0.0",
     "eslint-plugin-import": "^2.7.0",
@@ -56,5 +63,13 @@
     "globals": {
       "atom": true
     }
+  },
+  "release": {
+    "extends": "@semantic-release/apm-config"
+  },
+  "commitlint": {
+    "extends": [
+      "@commitlint/config-conventional"
+    ]
   }
 }


### PR DESCRIPTION
To ease the modification/contribution to publish pipeline there has been some discussion of adopting a continuous deployment system for AtomLinter packages. To accomplish this we are making use of [`semantic-release`](https://github.com/semantic-release/semantic-release) and [`@semantic-release/apm-config`](https://github.com/semantic-release/apm-config).

This pull request has been [dynamically created using a script](https://gist.github.com/keplersj/8bc7622ea741c0964d12842bfc679c5d). While the result is not perfect, it does accompish most of the grunt work of adopting continous deployment. There is some reconciliation that needs to be done before this can be merged.

Among the things needed to be reconciled, an [APM Token](https://atom.io/account) and [GitHub Token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) will need to be added to this repo's continous integration (most likely [Travis CI](https://docs.travis-ci.com/user/environment-variables#Defining-Variables-in-Repository-Settings)) configuration for automated deployments to work.

Again, this Pull Request has been created by a script made by @keplersj. Please mention him if something has gone wrong, and he'll be happy to help.

ref: AtomLinter/Meta#18

cc: @Arcanemagus
