### PR TITLE
ci: use a deploy pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,32 @@
 ### Project specific config ###
 language: node_js
 node_js: lts/*
+os: linux
 
-matrix:
-  include:
-    - os: linux
-      env: ATOM_CHANNEL=stable
-
-    - os: linux
-      env: ATOM_CHANNEL=beta
+env:
+  matrix:
+    - ATOM_CHANNEL=stable
+    - ATOM_CHANNEL=beta
 
 before_script:
   - commitlint-travis
 
-after_success:
-  # Add apm to the PATH
-  - export PATH=${PATH}:${HOME}/atom/usr/bin/
+stages:
+ - test
+ - name: release
+   if: (NOT type = pull_request) AND branch = master
 
-deploy:
-  provider: script
-  skip_cleanup: true
-  script:
-    - npx semantic-release
+jobs:
+  include:
+    - stage: release
+      node_js: lts/*
+      script:
+        - export PATH=${PATH}:${HOME}/atom/usr/bin/
+      deploy:
+        provider: script
+        skip_cleanup: true
+        script:
+          - npx semantic-release
 
 ### Generic setup follows ###
 script:


### PR DESCRIPTION
Currently both the beta and stable builds attempt to deploy, the only reason this didn't cause a major issue with the release of v1.3.0 is that the beta build `apm` command is actually `apm-beta`. Move the deploy to a separate job so this conflict doesn't happen again.

Closes #131.