### PR TITLE
ci: use install script for Atom

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
     - ATOM_CHANNEL=stable
     - ATOM_CHANNEL=beta
 
-before_script:
+script:
   - commitlint-travis
 
 stages:
@@ -29,7 +29,7 @@ jobs:
           - npx semantic-release
 
 ### Generic setup follows ###
-script:
+install:
   - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
   - chmod u+x build-package.sh
   - "./build-package.sh"


### PR DESCRIPTION
Run the `build-package.sh` script in the `install` stage so that `apm` is available for the `script` stage during the deploy job.