### PR TITLE
Upgrade to Linter API v2

### DIFF
--- a/lib/linter-js-yaml.js
+++ b/lib/linter-js-yaml.js
@@ -39,7 +39,7 @@ export default {
       grammarScopes: ['source.yaml', 'source.yml'],
       scope: 'file',
       name: 'Js-YAML',
-      lintOnFly: true,
+      lintsOnChange: true,
       lint: (TextEditor) => {
         if (!atom.workspace.isTextEditor(TextEditor)) {
           return null;
@@ -52,7 +52,7 @@ export default {
         const fileText = TextEditor.getText();
 
         const messages = [];
-        const processMessage = (type, message) => {
+        const processMessage = (severity, message) => {
           let { line } = message.mark;
           // Workaround for https://github.com/nodeca/js-yaml/issues/218
           const maxLine = TextEditor.getLineCount() - 1;
@@ -61,10 +61,12 @@ export default {
           }
           const { column } = message.mark;
           return {
-            type,
-            text: message.reason,
-            filePath,
-            range: helper.generateRange(TextEditor, line, column),
+            severity,
+            excerpt: message.reason,
+            location: {
+              file: filePath,
+              position: helper.generateRange(TextEditor, line, column),
+            },
           };
         };
 
@@ -73,11 +75,11 @@ export default {
             filename: path.basename(filePath),
             schema: this.Schema,
             onWarning: (warning) => {
-              messages.push(processMessage('Warning', warning));
+              messages.push(processMessage('warning', warning));
             },
           });
         } catch (error) {
-          messages.push(processMessage('Error', error));
+          messages.push(processMessage('error', error));
         }
 
         return messages;

--- a/package.json
+++ b/package.json
@@ -38,12 +38,12 @@
     "jasmine-fix": "^1.3.0"
   },
   "package-deps": [
-    "linter"
+    "linter:2.0.0"
   ],
   "providedServices": {
     "linter": {
       "versions": {
-        "1.0.0": "provideLinter"
+        "2.0.0": "provideLinter"
       }
     }
   },

--- a/spec/linter-spec.js
+++ b/spec/linter-spec.js
@@ -31,10 +31,10 @@ describe('Js-YAML provider for Linter', () => {
     const messages = await lint(editor);
 
     expect(messages.length).toBe(1);
-    expect(messages[0].type).toBe('Error');
-    expect(messages[0].text).toBe('end of the stream or a document separator is expected');
-    expect(messages[0].filePath).toBe(badPath);
-    expect(messages[0].range).toEqual([[2, 4], [2, 5]]);
+    expect(messages[0].severity).toBe('error');
+    expect(messages[0].excerpt).toBe('end of the stream or a document separator is expected');
+    expect(messages[0].location.file).toBe(badPath);
+    expect(messages[0].location.position).toEqual([[2, 4], [2, 5]]);
   });
 
   it('finds nothing wrong with issue-2.yaml.', async () => {
@@ -69,10 +69,10 @@ describe('Js-YAML provider for Linter', () => {
         atom.workspace.open(wrongNodeKind).then((editor) => {
           const messages = lint(editor);
           expect(messages.length).toBe(1);
-          expect(messages[0].type).toBe('Error');
-          expect(messages[0].text).toBe('unknown tag !<!epsilon>');
-          expect(messages[0].filePath).toBe(wrongNodeKind);
-          expect(messages[0].range).toEqual([[2, 34], [2, 34]]);
+          expect(messages[0].severity).toBe('error');
+          expect(messages[0].excerpt).toBe('unknown tag !<!epsilon>');
+          expect(messages[0].location.file).toBe(wrongNodeKind);
+          expect(messages[0].location.position).toEqual([[2, 34], [2, 34]]);
         })));
 
     it('finds nothing wrong with node-kinds.yaml.', () =>


### PR DESCRIPTION
Upgrade to the v2 Linter API to support newer versions of the `linter` package.

Fixes #150.